### PR TITLE
Set Default discrete_signal_to_noise_ratio to 0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ python3 -m twine upload dist/*
 | edge_density                   | \[0, 1\]    | None | Defines the density of edges in the generated DAG.  |
 | discrete_node_ratio            | \[0, 1\]    | None | Defines the percentage of nodes that shall be of discrete type. Depending on its value the appropriate model (multivariate normal, mixed gaussian, discrete only) is chosen. |
 | num_samples                    | \[1, Inf)   | None | Defines the number of samples that shall be generated from the DAG. |
-| discrete_signal_to_noise_ratio | \[0, 1\]    | 0.9 | Defines the probability that no noise is added within the mixed additive noise model. |
+| discrete_signal_to_noise_ratio | \[0, 1\]    | 0.5 | Defines the probability that no noise is added within the mixed additive noise model. |
 | min_discrete_value_classes     | \[2, Inf)  | 3 | Defines the minimum number of discrete classes a discrete variable shall have. |
 | max_discrete_value_classes     | \[2, Inf)  | 4 | Defines the maximum number of discrete classes a discrete variable shall have. |
 | continuous_noise_std           | \[0, Inf)   | 1.0 | Defines the standard deviation of gaussian noise added to continuous variables. |

--- a/manm_cs/__main__.py
+++ b/manm_cs/__main__.py
@@ -101,7 +101,7 @@ def parse_args():
     parser.add_argument('--num_samples', type=type_in_range(int, 1, None), required=True,
                         help='Defines the number of samples that shall be generated from the DAG.')
     parser.add_argument('--discrete_signal_to_noise_ratio', type=type_in_range(float, 0.0, 1.0),
-                        required=False, default=0.9,
+                        required=False, default=0.5,
                         help='Defines the probability that no noise is added within the mixed additive noise model.')
     parser.add_argument('--min_discrete_value_classes', type=type_in_range(int, 2, None), default=3,
                         required=False,


### PR DESCRIPTION
Set default value for discrete_signal_to_noise_ratio to 0.5.

- Values << 0.5 yield data where confounders generate too much dependence characteristics, hence, violates conditional independence characteristics for high dz
- Values >> 0.5 yield data too noisy data, where conditional independence characteristics cannot be identified.